### PR TITLE
Add conditional insertion of the honeypot

### DIFF
--- a/lib/rack/honeypot.rb
+++ b/lib/rack/honeypot.rb
@@ -25,7 +25,7 @@ module Rack
         status, headers, body = @app.call(env)
 
         if @always_enabled || honeypot_header_present?(headers)
-          body = insert_honeypot(response_body(body))
+          body = insert_honeypot(body)
           headers = response_headers(headers, body)
         end
 
@@ -49,7 +49,12 @@ module Rack
     end
     
     def response_body(response)
-      response.join("")
+      body = ""
+
+      # The body may not be an array, so we need to call #each here.
+      response.each {|part| body << part }
+
+      body
     end
     
     def response_headers(headers, body)
@@ -57,6 +62,7 @@ module Rack
     end
 
     def insert_honeypot(body)
+      body = response_body(body)
       body.gsub!(/<\/head>/, css + "\n</head>")
       body.gsub!(/<form(.*)>/, '<form\1>' + "\n" + div)
       body

--- a/test/test_honeypot.rb
+++ b/test/test_honeypot.rb
@@ -13,6 +13,8 @@ class HoneypotTest < Test::Unit::TestCase
 
   def setup
     @logger = stub("logger", :warn => nil)
+    @always_enabled = true
+    @honeypot_header = nil
   end
 
   def app
@@ -27,18 +29,16 @@ class HoneypotTest < Test::Unit::TestCase
       </html>
     BLOCK
 
-    hello_world_app = lambda do |env|
-      [
-        200,
-        {
-          'Content-Type'   => 'text/plain',
-          'Content-Length' => content.length.to_s
-        },
-        [content]
-      ]
-    end
+    headers = {
+      'Content-Type'   => 'text/plain',
+      'Content-Length' => content.length.to_s,
+    }
 
-    Rack::Honeypot.new(hello_world_app, :input_name => 'honeypot_email', :logger => @logger)
+    headers['X-Honeypot'] = @honeypot_header if @honeypot_header
+
+    hello_world_app = lambda {|env| [200, headers, [content]] }
+
+    Rack::Honeypot.new(hello_world_app, :input_name => 'honeypot_email', :logger => @logger, :always_enabled => @always_enabled)
   end
 
   def test_normal_request_should_go_through
@@ -50,27 +50,14 @@ class HoneypotTest < Test::Unit::TestCase
   def test_request_with_form_should_add_honeypot_css
     get '/'
     assert_equal 200, last_response.status
-    css = unindent <<-BLOCK
-      <style type='text/css' media='all'>
-        div.phonetoy {
-          display:none;
-        }
-      </style>
-    BLOCK
-    assert last_response.body.index(css)
+    assert includes_honeypot_css?
   end
 
   def test_request_with_form_should_add_honeypot_div
     get '/'
     assert_equal 200, last_response.status
   
-    div = unindent <<-BLOCK
-      <div class='phonetoy'>
-        <label for='honeypot_email'>Don't fill in this field</label>
-        <input type='text' name='honeypot_email' value=''/>
-      </div>
-    BLOCK
-    assert last_response.body.index(div)
+    assert includes_honeypot?
   end
   
   def test_spam_request_should_be_sent_to_dead_end
@@ -82,6 +69,52 @@ class HoneypotTest < Test::Unit::TestCase
   def test_spam_request_should_be_logged
     @logger.expects(:warn).with("[Rack::Honeypot] Spam bot detected; responded with null")
     post '/', :honeypot_email => 'joe@example.com'
+  end
+
+  def test_should_not_inject_honeypot_if_not_always_enabled
+    @always_enabled = false
+
+    get '/'
+
+    assert_equal 200, last_response.status
+    assert !includes_honeypot?
+    assert !includes_honeypot_css?
+  end
+
+  def test_should_inject_honeypot_if_not_always_enabled_but_honeypot_header_present
+    @always_enabled = false
+    @honeypot_header = "enabled"
+
+    get '/'
+
+    assert_equal 200, last_response.status
+    assert includes_honeypot?
+    assert includes_honeypot_css?
+  end
+
+  private
+
+  def includes_honeypot?
+    div = unindent <<-BLOCK
+      <div class='phonetoy'>
+        <label for='honeypot_email'>Don't fill in this field</label>
+        <input type='text' name='honeypot_email' value=''/>
+      </div>
+    BLOCK
+
+    last_response.body.index(div) != nil
+  end
+
+  def includes_honeypot_css?
+    css = unindent <<-BLOCK
+      <style type='text/css' media='all'>
+        div.phonetoy {
+          display:none;
+        }
+      </style>
+    BLOCK
+
+    last_response.body.index(css) != nil
   end
     
 end


### PR DESCRIPTION
If `:always_enabled => false` is passed to the middleware, the honeypot
is only inserted if the header `X-Honeypot` has the value `enabled`.
